### PR TITLE
This commit changes the mode code for the 'configuration-files.kubele…

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -343,4 +343,5 @@ version = "1.22.0"
     "migrate_v1.22.0_public-control-container-v0-7-15.lz4",
     "migrate_v1.22.0_bootstrap-commands-settings.lz4",
     "migrate_v1.22.0_bootstrap-commands-metadata.lz4",
+    "migrate_v1.22.0_kubernetes-service-config.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1275,6 +1275,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubernetes-service-config"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -51,6 +51,7 @@ members = [
     "settings-migrations/v1.22.0/public-control-container-v0-7-15",
     "settings-migrations/v1.22.0/bootstrap-commands-settings",
     "settings-migrations/v1.22.0/bootstrap-commands-metadata",
+    "settings-migrations/v1.23.0/kubernetes-service-config",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-1",

--- a/sources/settings-migrations/v1.22.0/kubernetes-service-config/Cargo.toml
+++ b/sources/settings-migrations/v1.22.0/kubernetes-service-config/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "kubernetes-service-config"
+version = "0.1.0"
+authors = ["Sparks Song <shijiao@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.22.0/kubernetes-service-config/src/main.rs
+++ b/sources/settings-migrations/v1.22.0/kubernetes-service-config/src/main.rs
@@ -1,0 +1,25 @@
+use migration_helpers::common_migrations::ReplaceStringMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+const OLD_MODE: &str = "0600";
+const NEW_MODE: &str = "0644";
+
+/// We bumped the version of the default control container
+fn run() -> Result<()> {
+    migrate(ReplaceStringMigration {
+        setting: "configuration-files.kubelet-exec-start-conf.mode",
+        old_val: OLD_MODE,
+        new_val: NEW_MODE,
+    })
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/shared-defaults/kubernetes-services.toml
+++ b/sources/shared-defaults/kubernetes-services.toml
@@ -50,7 +50,7 @@ template-path = "/usr/share/templates/kubelet-server-key"
 [configuration-files.kubelet-exec-start-conf]
 path = "/etc/systemd/system/kubelet.service.d/exec-start.conf"
 template-path = "/usr/share/templates/kubelet-exec-start-conf"
-mode = "0600"
+mode = "0644"
 
 [configuration-files.credential-provider-config-yaml]
 path = "/etc/kubernetes/kubelet/credential-provider-config.yaml"


### PR DESCRIPTION
…t-exec-start-conf'

setting in the kubernetes-services.toml file from its previous value to 0644.

The migration files have been updated accordingly to reflect this mode change for the kubelet-exec-start.conf configuration file.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**



**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
